### PR TITLE
Handle whitespace before sequence in deserialization

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -499,7 +499,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        match self.peek().ok_or(Error::EofWhileParsingValue)? {
+        match self.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
             b'[' => {
                 self.eat_char();
                 let ret = visitor.visit_seq(SeqAccess::new(self))?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -996,7 +996,6 @@ mod tests {
 
     // See https://iot.mozilla.org/wot/#thing-resource
     #[test]
-    #[ignore]
     fn wot() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Thing<'a> {
@@ -1056,7 +1055,7 @@ mod tests {
                 properties: Properties {
                     temperature: Property {
                         ty: Type::Number,
-                        unit: Some("celcius"),
+                        unit: Some("celsius"),
                         description: Some("An ambient temperature sensor"),
                         href: "/properties/temperature",
                     },


### PR DESCRIPTION
- Correctly handle whitespaces before sequence start

- Fix wot deserialization test, and remove ignore flag