### PR TITLE
Add to_slice serialization function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub mod ser;
 #[doc(inline)]
 pub use self::de::{from_slice, from_str};
 #[doc(inline)]
-pub use self::ser::{to_string, to_vec};
+pub use self::ser::{to_slice, to_string, to_vec};
 
 #[allow(deprecated)]
 unsafe fn uninitialized<T>() -> T {

--- a/src/ser/map.rs
+++ b/src/ser/map.rs
@@ -1,35 +1,24 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeMap<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    ser: &'a mut Serializer<B>,
+pub struct SerializeMap<'a, 'b> {
+    ser: &'a mut Serializer<'b>,
     first: bool,
 }
 
-impl<'a, B> SerializeMap<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(ser: &'a mut Serializer<B>) -> Self {
+impl<'a, 'b: 'a> SerializeMap<'a, 'b> {
+    pub(crate) fn new(ser: &'a mut Serializer<'b>) -> Self {
         SerializeMap { ser, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeMap for SerializeMap<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a, 'b: 'a> ser::SerializeMap for SerializeMap<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
     fn end(self) -> Result<Self::Ok> {
-        self.ser.buf.push(b'}')?;
+        self.ser.push(b'}')?;
         Ok(())
     }
 
@@ -38,11 +27,11 @@ where
         T: ser::Serialize,
     {
         if !self.first {
-            self.ser.buf.push(b',')?;
+            self.ser.push(b',')?;
         }
         self.first = false;
         key.serialize(&mut *self.ser)?;
-        self.ser.buf.extend_from_slice(b":")?;
+        self.ser.extend_from_slice(b":")?;
         Ok(())
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -22,8 +22,6 @@ pub type Result<T> = ::core::result::Result<T, Error>;
 pub enum Error {
     /// Buffer is full
     BufferFull,
-    /// Buffer is full
-    Test(usize),
     #[doc(hidden)]
     __Extensible,
 }
@@ -80,7 +78,7 @@ impl<'a> Serializer<'a> {
     fn extend_from_slice(&mut self, other: &[u8]) -> Result<()> {
         if self.idx + other.len() > self.buf.len() {
             // won't fit in the buf; don't modify anything and return an error
-            Err(Error::Test(self.buf.len()))
+            Err(Error::BufferFull)
         } else {
             for c in other {
                 unsafe { self.push_unchecked(c.clone()) };

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeSeq<'a, 'b> {
+    de: &'a mut Serializer<'b>,
     first: bool,
 }
 
-impl<'a, B> SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a, 'b: 'a> SerializeSeq<'a, 'b> {
+    pub(crate) fn new(de: &'a mut Serializer<'b>) -> Self {
         SerializeSeq { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeSeq for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a, 'b: 'a> ser::SerializeSeq for SerializeSeq<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
@@ -33,7 +22,7 @@ where
         T: ser::Serialize,
     {
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.push(b',')?;
         }
         self.first = false;
 
@@ -42,15 +31,12 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b']')?;
+        self.de.push(b']')?;
         Ok(())
     }
 }
 
-impl<'a, B> ser::SerializeTuple for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a, 'b: 'a> ser::SerializeTuple for SerializeSeq<'a, 'b> {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    ser: &'a mut Serializer<B>,
+pub struct SerializeStruct<'a, 'b> {
+    ser: &'a mut Serializer<'b>,
     first: bool,
 }
 
-impl<'a, B> SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(ser: &'a mut Serializer<B>) -> Self {
+impl<'a, 'b: 'a> SerializeStruct<'a, 'b> {
+    pub(crate) fn new(ser: &'a mut Serializer<'b>) -> Self {
         SerializeStruct { ser, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeStruct for SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a, 'b: 'a> ser::SerializeStruct for SerializeStruct<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
@@ -34,13 +23,13 @@ where
     {
         // XXX if `value` is `None` we not produce any output for this field
         if !self.first {
-            self.ser.buf.push(b',')?;
+            self.ser.push(b',')?;
         }
         self.first = false;
 
-        self.ser.buf.push(b'"')?;
-        self.ser.buf.extend_from_slice(key.as_bytes())?;
-        self.ser.buf.extend_from_slice(b"\":")?;
+        self.ser.push(b'"')?;
+        self.ser.extend_from_slice(key.as_bytes())?;
+        self.ser.extend_from_slice(b"\":")?;
 
         value.serialize(&mut *self.ser)?;
 
@@ -48,7 +37,7 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.ser.buf.push(b'}')?;
+        self.ser.push(b'}')?;
         Ok(())
     }
 }


### PR DESCRIPTION
- Add a `to_slice` function when serializing, that allows serialization into an external buffer, eliminating the need for an additional copy in some cases. 
- Change `to_vec` to make use of above introduced `to_slice`
- Change `to_string` to make use of `to_vec` with an additional utf8 check


Fixes #35