### PR TITLE
Adding support for deserializing floats without termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-...
+### Changed
+- Floating point numbers terminated by EOF may now be deserialized
 
 ## [v0.2.0] - 2020-12-11
 ### Added


### PR DESCRIPTION
This PR fixes #47 by correcting the method used to parse floating point numbers to allow them to be terminated with an EOF.

I've also added unit tests to exercise this condition for basic data types.