### PR TITLE
Use ryu for float serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Floating point numbers terminated by EOF may now be deserialized
+- [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
 
 ## [v0.2.0] - 2020-12-11
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/rust-embedded-community/serde-json-core"
 version = "0.2.0"
 
 [dependencies]
-heapless = "0.5.0"
+heapless = "0.5.6"
+ryu = "1.0.5"
 
 [dependencies.serde]
 default-features = false


### PR DESCRIPTION
... supposedly pulling in the advantages of ryu (speed, code size?) over `core::fmt`.

The bigger and likely more valuable task would be deserialization and replacing `::from_str` by something else. As mentioned in #12, last time I tried, `lexical_core`'s `atof` wasn't easy.