### PR TITLE
serialize_bytes is not unreachable now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Floating point numbers terminated by EOF may now be deserialized
 - [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
+- Added missing implementation for `serialize_bytes` method
 
 ## [v0.2.0] - 2020-12-11
 ### Added

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -795,4 +795,32 @@ mod tests {
             r#"{"A":{"x":54,"y":720}}"#
         );
     }
+
+    #[test]
+    fn test_serialize_bytes() {
+        pub struct SimpleDecimal(f32);
+        
+        use core::fmt::Write;
+        use heapless::{consts::U48, String};
+
+        impl serde::Serialize for SimpleDecimal {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut aux: String<U48> = String::new();
+                write!(aux, "{:.2}", self.0).unwrap();
+                serializer.serialize_bytes(&aux.as_bytes())
+            }
+        }
+
+        let sd1 =  SimpleDecimal(1.55555);
+        assert_eq!(&*crate::to_string::<N, _>(&sd1).unwrap(), r#"1.56"#);
+        
+        let sd2 =  SimpleDecimal(0.00);
+        assert_eq!(&*crate::to_string::<N, _>(&sd2).unwrap(), r#"0.00"#);
+        
+        let sd3 =  SimpleDecimal(22222.777777);
+        assert_eq!(&*crate::to_string::<N, _>(&sd3).unwrap(), r#"22222.78"#);
+    }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -798,10 +798,10 @@ mod tests {
 
     #[test]
     fn test_serialize_bytes() {
-        pub struct SimpleDecimal(f32);
-        
         use core::fmt::Write;
         use heapless::{consts::U48, String};
+
+        pub struct SimpleDecimal(f32);
 
         impl serde::Serialize for SimpleDecimal {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -814,13 +814,13 @@ mod tests {
             }
         }
 
-        let sd1 =  SimpleDecimal(1.55555);
+        let sd1 = SimpleDecimal(1.55555);
         assert_eq!(&*crate::to_string::<N, _>(&sd1).unwrap(), r#"1.56"#);
-        
-        let sd2 =  SimpleDecimal(0.00);
+
+        let sd2 = SimpleDecimal(0.000);
         assert_eq!(&*crate::to_string::<N, _>(&sd2).unwrap(), r#"0.00"#);
-        
-        let sd3 =  SimpleDecimal(22222.777777);
+
+        let sd3 = SimpleDecimal(22222.777777);
         assert_eq!(&*crate::to_string::<N, _>(&sd3).unwrap(), r#"22222.78"#);
     }
 }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -304,8 +304,8 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
         self.push(b'"')
     }
 
-    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok> {
-        unreachable!()
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
+        self.extend_from_slice(v)
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {


### PR DESCRIPTION
`serialize_bytes` can push to output JSON raw bytes now. I now it can produce JSON with invalid data so it should be used with caution. I added this because I need a way to serialize f32 with fixed precision. 
Example:

```rust

pub struct SimpleDecimal(f32);

impl Serialize for SimpleDecimal {
    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: Serializer,
    {
        let mut aux: String<U48> = String::new();
        write!(aux, "{:.2}", self.0).unwrap();
        serializer.serialize_bytes(&aux.as_bytes())
    }
}


```