### PR TITLE
Updating heapless and allowing external usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `heapless` is now publicly exported
+
 ### Changed
 - Floating point numbers terminated by EOF may now be deserialized
 - [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
 - Added missing implementation for `serialize_bytes` method
-
-- Publicly re-export `heapless` dependency to allow for external usage.
 - [breaking-change] Heapless dependency updated to 0.6.1
+
 ## [v0.2.0] - 2020-12-11
 ### Added
 - Support for serialization into slices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
 - Added missing implementation for `serialize_bytes` method
 
-### Breaking
-- Heapless dependency updated to 0.6.1 - publicly exporting heapless for external use.
-
+- Publicly re-export `heapless` dependency to allow for external usage.
+- [breaking-change] Heapless dependency updated to 0.6.1
 ## [v0.2.0] - 2020-12-11
 ### Added
 - Support for serialization into slices
@@ -41,4 +40,3 @@ Initial release
 [Unreleased]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.2.0...HEAD
 [v0.2.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/rust-embedded-community/serde-json-core/releases/tag/v0.1.0
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
 - Added missing implementation for `serialize_bytes` method
 
+### Breaking
+- Heapless dependency updated to 0.6.1 - publicly exporting heapless for external use.
+
 ## [v0.2.0] - 2020-12-11
 ### Added
 - Support for serialization into slices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - `heapless` is now publicly exported
+- Added new `serialize_bytes` method
 
 ### Changed
 - Floating point numbers terminated by EOF may now be deserialized
 - [ryu](https://github.com/dtolnay/ryu) is used to serialize `f32` and `f64`
-- Added missing implementation for `serialize_bytes` method
 - [breaking-change] Heapless dependency updated to 0.6.1
 
 ## [v0.2.0] - 2020-12-11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rust-embedded-community/serde-json-core"
 version = "0.2.0"
 
 [dependencies]
-heapless = "0.5.6"
+heapless = "0.6.1"
 ryu = "1.0.5"
 
 [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub use self::de::{from_slice, from_str};
 #[doc(inline)]
 pub use self::ser::{to_slice, to_string, to_vec};
 
+pub use heapless;
+
 #[allow(deprecated)]
 unsafe fn uninitialized<T>() -> T {
     core::mem::uninitialized()


### PR DESCRIPTION
This PR fixes #52 by publicly using `heapless`. It also updates the heapless version to use a version that does not have a security vulnerability in it.