### PR TITLE
make heapless optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+
+- Support for opting out of heapless integration
 
 ## [v0.3.0] - 2021-04-29
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,11 @@ repository = "https://github.com/rust-embedded-community/serde-json-core"
 version = "0.3.0"
 
 [dependencies]
-heapless = "0.6.1"
 ryu = "1.0.5"
+
+[dependencies.heapless]
+version = "0.6.1"
+optional = true
 
 [dependencies.serde]
 default-features = false
@@ -23,5 +26,6 @@ version = "1.0.80"
 serde_derive = "1.0.80"
 
 [features]
-custom-error-messages = []
+default = ["heapless"]
+custom-error-messages = ["heapless"]
 std = ["serde/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,11 @@ pub mod ser;
 #[doc(inline)]
 pub use self::de::{from_slice, from_str};
 #[doc(inline)]
-pub use self::ser::{to_slice, to_string, to_vec};
+pub use self::ser::to_slice;
+#[cfg(feature = "heapless")]
+pub use self::ser::{to_string, to_vec};
 
+#[cfg(feature = "heapless")]
 pub use heapless;
 
 #[allow(deprecated)]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use serde::ser;
 use serde::ser::SerializeStruct as _;
 
+#[cfg(feature = "heapless")]
 use heapless::{String, Vec};
 
 use self::map::SerializeMap;
@@ -423,6 +424,7 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
 }
 
 /// Serializes the given data structure as a string of JSON text
+#[cfg(feature = "heapless")]
 pub fn to_string<B, T>(value: &T) -> Result<String<B>>
 where
     B: heapless::ArrayLength<u8>,
@@ -432,6 +434,7 @@ where
 }
 
 /// Serializes the given data structure as a JSON byte vector
+#[cfg(feature = "heapless")]
 pub fn to_vec<B, T>(value: &T) -> Result<Vec<u8, B>>
 where
     B: heapless::ArrayLength<u8>,


### PR DESCRIPTION
* Makes heapless an optional dep
* Feature gate heapless uses throughout the code
* Enable heapless feature by default for backwards compat

My rational is that I only ever use the `{to,from}_slice` methods in this crate, pulling in a heapless dep for no reason.