### PR TITLE
float inf nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed serialization of `f32`/`f64` that are `!is_finite()` (i.e. `NAN`, `INFINITY`,
+  `NEG_INFINITY`) to result in JSON `null`. This matches `serde_json` behavior.
+- Changed deserialization of JSON `null` where `f32`/`f64` is expected to result in
+  the respective `NAN`.
+
 ## [v0.4.0] - 2021-05-08
 
 ### Added

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -948,11 +948,17 @@ mod tests {
             ))
         );
 
+        // NaNs will always compare unequal.
+        let (r, n): (Temperature, usize) = crate::from_str(r#"{ "temperature": null }"#).unwrap();
+        assert!(r.temperature.is_nan());
+        assert_eq!(n, 23);
+
         assert!(crate::from_str::<Temperature>(r#"{ "temperature": 1e1e1 }"#).is_err());
         assert!(crate::from_str::<Temperature>(r#"{ "temperature": -2-2 }"#).is_err());
         assert!(crate::from_str::<Temperature>(r#"{ "temperature": 1 1 }"#).is_err());
         assert!(crate::from_str::<Temperature>(r#"{ "temperature": 0.0. }"#).is_err());
         assert!(crate::from_str::<Temperature>(r#"{ "temperature": ä }"#).is_err());
+        assert!(crate::from_str::<Temperature>(r#"{ "temperature": None }"#).is_err());
     }
 
     #[test]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -311,23 +311,32 @@ macro_rules! deserialize_signed {
 
 macro_rules! deserialize_fromstr {
     ($self:ident, $visitor:ident, $typ:ident, $visit_fn:ident, $pattern:expr) => {{
-        let start = $self.index;
-        while $self.peek().is_some() {
-            let c = $self.peek().unwrap();
-            if $pattern.iter().find(|&&d| d == c).is_some() {
+        match $self.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
+            b'n' => {
                 $self.eat_char();
-            } else {
-                break;
+                $self.parse_ident(b"ull")?;
+                $visitor.$visit_fn($typ::NAN)
+            }
+            _ => {
+                let start = $self.index;
+                while $self.peek().is_some() {
+                    let c = $self.peek().unwrap();
+                    if $pattern.iter().find(|&&d| d == c).is_some() {
+                        $self.eat_char();
+                    } else {
+                        break;
+                    }
+                }
+
+                // Note(unsafe): We already checked that it only contains ascii. This is only true if the
+                // caller has guaranteed that `pattern` contains only ascii characters.
+                let s = unsafe { str::from_utf8_unchecked(&$self.slice[start..$self.index]) };
+
+                let v = $typ::from_str(s).or(Err(Error::InvalidNumber))?;
+
+                $visitor.$visit_fn(v)
             }
         }
-
-        // Note(unsafe): We already checked that it only contains ascii. This is only true if the
-        // caller has guaranteed that `pattern` contains only ascii characters.
-        let s = unsafe { str::from_utf8_unchecked(&$self.slice[start..$self.index]) };
-
-        let v = $typ::from_str(s).or(Err(Error::InvalidNumber))?;
-
-        $visitor.$visit_fn(v)
     }};
 }
 
@@ -423,7 +432,6 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
         deserialize_fromstr!(self, visitor, f32, visit_f32, b"0123456789+-.eE")
     }
 
@@ -431,7 +439,6 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
         deserialize_fromstr!(self, visitor, f64, visit_f64, b"0123456789+-.eE")
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -353,7 +353,7 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
-        mut self,
+        self,
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
@@ -363,7 +363,7 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
         T: ser::Serialize,
     {
         self.push(b'{')?;
-        let mut s = SerializeStruct::new(&mut self);
+        let mut s = SerializeStruct::new(self);
         s.serialize_field(variant, value)?;
         s.end()?;
         Ok(())

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -708,6 +708,22 @@ mod tests {
             .unwrap(),
             r#"{"temperature":-2.3456788e-23}"#
         );
+
+        assert_eq!(
+            &*crate::to_string::<_, N>(&Temperature {
+                temperature: f32::NAN
+            })
+            .unwrap(),
+            r#"{"temperature":null}"#
+        );
+
+        assert_eq!(
+            &*crate::to_string::<_, N>(&Temperature {
+                temperature: f32::NEG_INFINITY
+            })
+            .unwrap(),
+            r#"{"temperature":null}"#
+        );
     }
 
     #[test]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -230,11 +230,19 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
-        serialize_ryu!(self, v)
+        if v.is_finite() {
+            serialize_ryu!(self, v)
+        } else {
+            self.serialize_none()
+        }
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok> {
-        serialize_ryu!(self, v)
+        if v.is_finite() {
+            serialize_ryu!(self, v)
+        } else {
+            self.serialize_none()
+        }
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok> {


### PR DESCRIPTION
Currently `f{32,64}::NAN`, `INFINITE` and `NEG_INFINITY` (i.e. if `!v.is_finite()`) are all emitted like their `ryu` serializations. This is wrong and breaks JSON.
Instead, emit `null`, like `serde_json` does.
On deserialization, interpret `null` as `NAN` where `f32` or `f64` is expected. This isn't exactly what `serde_json` does (it errors out instead), but makes the round-trip closer somewhat more robust. And many would claim that it is common to interpret a JSON `null` as `NAN` where a float is expected (from schema/context/protocol).