### PR TITLE
derive standard traits for Errors

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -17,7 +17,8 @@ mod seq;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// This type represents all possible errors that can occur when deserializing JSON data
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(not(feature = "custom-error-messages"), derive(Copy))]
 #[non_exhaustive]
 pub enum Error {
     /// EOF while parsing a list.
@@ -73,7 +74,7 @@ pub enum Error {
 
     /// Error with a custom message that was preserved.
     #[cfg(feature = "custom-error-messages")]
-    CustomErrorWithMessage(heapless::String<heapless::consts::U64>),
+    CustomErrorWithMessage(heapless::String<64>),
 }
 
 #[cfg(feature = "std")]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -20,7 +20,7 @@ mod struct_;
 pub type Result<T> = ::core::result::Result<T, Error>;
 
 /// This type represents all possible errors that can occur when serializing JSON data
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[non_exhaustive]
 pub enum Error {
     /// Buffer is full


### PR DESCRIPTION
* Copy only if `not(feature = custom-error-messages)`
* Also fix the custom-error-messages feature to use const generics
  String