### PR TITLE
MaybeUninit, serde StdError, unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.51.0
+          - rust: 1.55.0  # keep in sync with manifest rust-version
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `NEG_INFINITY`) to result in JSON `null`. This matches `serde_json` behavior.
 - Changed deserialization of JSON `null` where `f32`/`f64` is expected to result in
   the respective `NAN`.
+- [breaking-change] increase MSRV to Rust `1.55.0` due to `maybe_uninit_extra`.
 
 ## [v0.4.0] - 2021-05-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.serde]
 default-features = false
-version = "1.0.80"
+version = "1.0.100"
 
 [dev-dependencies]
 serde_derive = "1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ categories = ["no-std"]
 description = "serde-json for no_std programs"
 documentation = "https://docs.rs/serde-json-core"
 edition = "2018"
+rust-version = "1.55.0"  # keep in sync with ci
 keywords = ["serde", "json"]
 license = "MIT OR Apache-2.0"
 name = "serde-json-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-features = false
 version = "1.0.100"
 
 [dev-dependencies]
-serde_derive = "1.0.80"
+serde_derive = "1.0.100"
 
 [features]
 default = ["heapless"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -84,6 +84,8 @@ impl ::std::error::Error for Error {
     }
 }
 
+impl serde::de::StdError for Error {}
+
 pub(crate) struct Deserializer<'b> {
     slice: &'b [u8],
     index: usize,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1093,6 +1093,46 @@ mod tests {
     }
 
     #[test]
+    fn struct_with_array_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test {
+            status: bool,
+            point: [u32; 3],
+        }
+
+        assert_eq!(
+            crate::from_str(r#"{ "status": true, "point": [1, 2, 3] }"#),
+            Ok((
+                Test {
+                    status: true,
+                    point: [1, 2, 3]
+                },
+                38
+            ))
+        );
+    }
+
+    #[test]
+    fn struct_with_tuple_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Test {
+            status: bool,
+            point: (u32, u32, u32),
+        }
+
+        assert_eq!(
+            crate::from_str(r#"{ "status": true, "point": [1, 2, 3] }"#),
+            Ok((
+                Test {
+                    status: true,
+                    point: (1, 2, 3)
+                },
+                38
+            ))
+        );
+    }
+
+    #[test]
     fn ignoring_extra_fields() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Temperature {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -77,13 +77,6 @@ pub enum Error {
     CustomErrorWithMessage(heapless::String<64>),
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-        ""
-    }
-}
-
 impl serde::de::StdError for Error {}
 
 pub(crate) struct Deserializer<'b> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,3 @@ pub use self::ser::{to_string, to_vec};
 
 #[cfg(feature = "heapless")]
 pub use heapless;
-
-#[allow(deprecated)]
-unsafe fn uninitialized<T>() -> T {
-    core::mem::uninitialized()
-}

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -40,13 +40,6 @@ impl From<u8> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-        ""
-    }
-}
-
 impl serde::ser::StdError for Error {}
 
 impl fmt::Display for Error {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -47,6 +47,8 @@ impl ::std::error::Error for Error {
     }
 }
 
+impl serde::ser::StdError for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Buffer is full")


### PR DESCRIPTION
This takes the remaining bits from https://github.com/rust-embedded-community/serde-json-core/pull/59 by @jordy25519

* MaybeUninint instead of the deprecated mem::uninitialized (given the unstable maybe_uninit_slice feature, in the future this should use [slice_assume_init_ref](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref))
* Two unittests
* serde::*::StdError for our Errors
* The bump in serde version further is not needed or helpful AFAICT (this is a library).
* The reorganization of the code using MaybeUninit in #59 is not necessary