### PR TITLE
Add support for serialising tuple structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Support for serializing tuple structs. These are serialized as JSON arrays,
+  which matches `serde_json` behaviour.
+
 ## [v0.5.0] - 2022-11-04
 
 ### Changed
@@ -61,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
+[Unreleased]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.0...HEAD
 [v0.5.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.2.0...v0.3.0

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -178,7 +178,7 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
     type Error = Error;
     type SerializeSeq = SerializeSeq<'a, 'b>;
     type SerializeTuple = SerializeSeq<'a, 'b>;
-    type SerializeTupleStruct = Unreachable;
+    type SerializeTupleStruct = SerializeSeq<'a, 'b>;
     type SerializeTupleVariant = Unreachable;
     type SerializeMap = SerializeMap<'a, 'b>;
     type SerializeStruct = SerializeStruct<'a, 'b>;
@@ -385,9 +385,9 @@ impl<'a, 'b: 'a> ser::Serializer for &'a mut Serializer<'b> {
     fn serialize_tuple_struct(
         self,
         _name: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
-        unreachable!()
+        self.serialize_seq(Some(len))
     }
 
     fn serialize_tuple_variant(
@@ -819,6 +819,19 @@ mod tests {
         assert_eq!(
             &*crate::to_string::<_, N>(&a).unwrap(),
             r#"{"A":{"x":54,"y":720}}"#
+        );
+    }
+
+    #[test]
+    fn test_tuple_struct() {
+        #[derive(Serialize)]
+        struct A<'a>(u32, Option<&'a str>, u16, bool);
+
+        let a = A(42, Some("A string"), 720, false);
+
+        assert_eq!(
+            &*crate::to_string::<_, N>(&a).unwrap(),
+            r#"[42,"A string",720,false]"#
         );
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -836,6 +836,19 @@ mod tests {
     }
 
     #[test]
+    fn test_tuple_struct_roundtrip() {
+        use serde_derive::Deserialize;
+
+        #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+        struct A<'a>(u32, Option<&'a str>, u16, bool);
+
+        let a1 = A(42, Some("A string"), 720, false);
+        let serialized = crate::to_string::<_, N>(&a1).unwrap();
+        let (a2, _size): (A<'_>, usize) = crate::from_str(&serialized).unwrap();
+        assert_eq!(a1, a2);
+    }
+
+    #[test]
     fn test_serialize_bytes() {
         use core::fmt::Write;
         use heapless::String;

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -51,3 +51,19 @@ impl<'a, 'b: 'a> ser::SerializeTuple for SerializeSeq<'a, 'b> {
         ser::SerializeSeq::end(self)
     }
 }
+
+impl<'a, 'b: 'a> ser::SerializeTupleStruct for SerializeSeq<'a, 'b> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        ser::SerializeSeq::end(self)
+    }
+}


### PR DESCRIPTION
Following the convention described in [serde's documentation](https://serde.rs/json.html), add support for serialising tuple structs as a JSON array. Tuple struct deserialisation is supported already, just serialisation support was missing. 