### PR TITLE
add optional defmt support for error types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.TARGET }}
+          args: --target=${{ matrix.TARGET }} --all-features
       - uses: actions-rs/cargo@v1
         if: ${{ contains(matrix.TARGET, 'x86_64') }}
         with:
           command: test
-          args: --target=${{ matrix.TARGET }}
+          args: --target=${{ matrix.TARGET }} --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added 
+
+- Support for optional package `defmt` which allows for easy conversion for
+error types when using tools like `probe-rs` for logging over debuggers.
+
 ## [v0.5.1] - 2023-07-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ optional = true
 default-features = false
 version = "1.0.100"
 
+[dependencies.defmt]
+version = "0.3.0"
+default-features = false
+optional = true
+
 [dev-dependencies]
 serde_derive = "1.0.100"
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -19,6 +19,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// This type represents all possible errors that can occur when deserializing JSON data
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(not(feature = "custom-error-messages"), derive(Copy))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// EOF while parsing a list.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -22,6 +22,7 @@ pub type Result<T> = ::core::result::Result<T, Error>;
 
 /// This type represents all possible errors that can occur when serializing JSON data
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// Buffer is full


### PR DESCRIPTION
add defmt as an optional dependent package

I am only able to test defmt v0.3.0 as the rest of my project is using that version the latest is at v0.3.5

closes #75