### PR TITLE
Enable serde feature for heapless dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ryu = "1.0.5"
 [dependencies.heapless]
 version = "0.8"
 optional = true
+features = ["serde"]
 
 [dependencies.serde]
 default-features = false


### PR DESCRIPTION
This results in the serde trait implementations being available when using the `serde_json_core::heapless` re-exports.