### PR TITLE
Preparing for v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ error types when using tools like `probe-rs` for logging over debuggers.
 Initial release
 
 [Unreleased]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.6.0...HEAD
-[v0.5.1]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.1...v0.6.0
+[v0.6.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.1...v0.6.0
 [v0.5.1]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.0] - 2024-08-07
+
 ### Breaking
 - MSRV is now `1.65.0`.
 
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 error types when using tools like `probe-rs` for logging over debuggers.
 - Implement `Serializer::collect_str`
 - Derive `Serialize` for `de::Error` and `ser::Error`
-- Support for deserializing escaped strings.
+- Support for deserializing escaped strings using `from_str_escaped` and `from_slice_escaped`.
 
 ### Changed
 
@@ -91,7 +93,8 @@ error types when using tools like `probe-rs` for logging over debuggers.
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.6.0...HEAD
+[v0.5.1]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.1...v0.6.0
 [v0.5.1]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/rust-embedded-community/serde-json-core/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = ["Jorge Aparicio <jorge@japaric.io>",
+           "Ryan Summers <ryan.summers@vertigo-designs.com>",
+           "Robert Jördens <rj@quartiq.de>",
+           "Mathias Koch <mk@factbird.com>"
+]
 categories = ["no-std"]
 description = "serde-json for no_std programs"
 documentation = "https://docs.rs/serde-json-core"
@@ -10,7 +14,7 @@ license = "MIT OR Apache-2.0"
 name = "serde-json-core"
 readme = "README.md"
 repository = "https://github.com/rust-embedded-community/serde-json-core"
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 ryu = "1.0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,27 @@
 //! This version of [`serde-json`] is aimed at applications that run on resource constrained
 //! devices.
 //!
+//! ## Example
+//! ```
+//! # use serde::{Serialize, Deserialize};
+//! #[derive(Serialize, Deserialize)]
+//! struct Data<'a> {
+//!     value: u32,
+//!     message: &'a str,
+//! }
+//!
+//! // Serialized JSON data can be easily deserialized into Rust types.
+//! let message = b"{\"value\":10,\"message\":\"Hello, World!\"}";
+//! let (data, _remainder) = serde_json_core::from_slice::<Data<'_>>(message).unwrap();
+//! assert_eq!(data.value, 10);
+//! assert_eq!(data.message, "Hello, World!");
+//!
+//! // Structures can also be serialized into slices or strings.
+//! let mut deserialized = [0u8; 256];
+//! let len = serde_json_core::to_slice(&data, &mut deserialized[..]).unwrap();
+//! assert_eq!(&deserialized[..len], message);
+//! ```
+//!
 //! # Current features
 //!
 //! - The error type is a simple C like enum (less overhead, smaller memory footprint)
@@ -16,7 +37,7 @@
 //!   - `bool`
 //!   - Integers
 //!   - Floats
-//!   - `str` (This is a zero copy operation.) (\*)
+//!   - `str` (This is a zero copy operation when deserializing without de-escaping strings.)
 //!   - `Option`
 //!   - Arrays
 //!   - Tuples
@@ -32,9 +53,6 @@
 //!   - Tuples
 //!   - Structs
 //!   - C like enums
-//!
-//! (\*) Deserialization of strings ignores escaped sequences. Escaped sequences might be supported
-//! in the future using a different Serializer as this operation is not zero copy.
 //!
 //! (\*\*) Serialization of strings doesn't escape stuff. This simply has not been implemented yet.
 //!


### PR DESCRIPTION
Fixes #89 by releasing this crate as v0.6.0
Fixes #82 by adding some README documentation on the basics of how to serde with this crate.