### PR TITLE
Clean up naming in from_slice return value in example

### DIFF
--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -12,7 +12,7 @@ impl<'a, 'b, 's> UnitVariantAccess<'a, 'b, 's> {
     }
 }
 
-impl<'a, 'de, 's> de::EnumAccess<'de> for UnitVariantAccess<'a, 'de, 's> {
+impl<'de> de::EnumAccess<'de> for UnitVariantAccess<'_, 'de, '_> {
     type Error = Error;
     type Variant = Self;
 
@@ -64,7 +64,7 @@ impl<'a, 'b, 's> VariantAccess<'a, 'b, 's> {
     }
 }
 
-impl<'a, 'de, 's> de::EnumAccess<'de> for VariantAccess<'a, 'de, 's> {
+impl<'de> de::EnumAccess<'de> for VariantAccess<'_, 'de, '_> {
     type Error = Error;
     type Variant = Self;
 

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -25,7 +25,7 @@ impl<'de> de::EnumAccess<'de> for UnitVariantAccess<'_, 'de, '_> {
     }
 }
 
-impl<'de, 'a, 's> de::VariantAccess<'de> for UnitVariantAccess<'a, 'de, 's> {
+impl<'de> de::VariantAccess<'de> for UnitVariantAccess<'_, 'de, '_> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
@@ -78,7 +78,7 @@ impl<'de> de::EnumAccess<'de> for VariantAccess<'_, 'de, '_> {
     }
 }
 
-impl<'de, 'a, 's> de::VariantAccess<'de> for VariantAccess<'a, 'de, 's> {
+impl<'de> de::VariantAccess<'de> for VariantAccess<'_, 'de, '_> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -61,7 +61,7 @@ struct MapKey<'a, 'b, 's> {
     de: &'a mut Deserializer<'b, 's>,
 }
 
-impl<'de, 'a, 's> de::Deserializer<'de> for MapKey<'a, 'de, 's> {
+impl<'de> de::Deserializer<'de> for MapKey<'_, 'de, '_> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Error>

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -13,7 +13,7 @@ impl<'a, 'b, 's> MapAccess<'a, 'b, 's> {
     }
 }
 
-impl<'a, 'de, 's> de::MapAccess<'de> for MapAccess<'a, 'de, 's> {
+impl<'de> de::MapAccess<'de> for MapAccess<'_, 'de, '_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -381,7 +381,7 @@ macro_rules! deserialize_fromstr {
     }};
 }
 
-impl<'a, 'de, 's> de::Deserializer<'de> for &'a mut Deserializer<'de, 's> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de, '_> {
     type Error = Error;
 
     /// Unsupported. Can’t parse a value without knowing its expected type.
@@ -608,7 +608,7 @@ impl<'a, 'de, 's> de::Deserializer<'de> for &'a mut Deserializer<'de, 's> {
 
             struct EscapedStringDeserializer<'a, 'de, 's>(&'a mut Deserializer<'de, 's>);
 
-            impl<'a, 'de, 's> serde::Deserializer<'de> for EscapedStringDeserializer<'a, 'de, 's> {
+            impl<'de> serde::Deserializer<'de> for EscapedStringDeserializer<'_, 'de, '_> {
                 type Error = Error;
 
                 fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -13,7 +13,7 @@ impl<'a, 'b, 's> SeqAccess<'a, 'b, 's> {
     }
 }
 
-impl<'a, 'de, 's> de::SeqAccess<'de> for SeqAccess<'a, 'de, 's> {
+impl<'de> de::SeqAccess<'de> for SeqAccess<'_, 'de, '_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! // Serialized JSON data can be easily deserialized into Rust types.
 //! let message = b"{\"value\":10,\"message\":\"Hello, World!\"}";
-//! let (data, _remainder) = serde_json_core::from_slice::<Data<'_>>(message).unwrap();
+//! let (data, _consumed) = serde_json_core::from_slice::<Data<'_>>(message).unwrap();
 //! assert_eq!(data.value, 10);
 //! assert_eq!(data.message, "Hello, World!");
 //!

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -651,7 +651,7 @@ impl<'a, 'b> StringCollector<'a, 'b> {
     }
 }
 
-impl<'a, 'b> fmt::Write for StringCollector<'a, 'b> {
+impl fmt::Write for StringCollector<'_, '_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.do_write_str(s).or(Err(fmt::Error))
     }


### PR DESCRIPTION
The second element of the returned tuple is the number of bytes consumed as stated in the docs of this function. Let's remove this red herring for the ones no looking into the [function docs](https://docs.rs/serde-json-core/0.6.0/serde_json_core/fn.from_slice.html).