### PR TITLE
Remove wrong note about missing string escaping.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,12 @@
 //!   - `bool`
 //!   - Integers
 //!   - Floats
-//!   - `str` (\*\*)
+//!   - `str`
 //!   - `Option`
 //!   - Arrays
 //!   - Tuples
 //!   - Structs
 //!   - C like enums
-//!
-//! (\*\*) Serialization of strings doesn't escape stuff. This simply has not been implemented yet.
 //!
 //! # Planned features
 //!


### PR DESCRIPTION
String escaping during serialization is implemented and tested.

Closes #92

/edit: See #102 for a fix for CI.